### PR TITLE
Feature/jihirshu/match subscriber qos profile

### DIFF
--- a/ros_tcp_endpoint/default_server_endpoint.py
+++ b/ros_tcp_endpoint/default_server_endpoint.py
@@ -14,7 +14,7 @@ def main(args=None):
     tcp_server.setup_executor()
 
     tcp_server.destroy_nodes()
-    rclpy.shutdown()
+    rclpy.try_shutdown()
 
 
 if __name__ == "__main__":

--- a/ros_tcp_endpoint/subscriber.py
+++ b/ros_tcp_endpoint/subscriber.py
@@ -94,13 +94,14 @@ class RosSubscriber(RosReceiver):
                 self.get_logger().warn(
                     f"No publisher found for topic {topic}, using default QoS"
                 )
-                if not self.check_qos_timer:
-                    self.check_qos_timer = self.create_timer(
-                        QOS_CHECK_TIMERR_PERIOD, self.check_qos_match
-                    )
         except Exception as e:
             self.get_logger().warn(
                 f"Failed to match QoS for topic {topic}: {e}, using default QoS"
+            )
+
+        if not self.check_qos_timer:
+            self.check_qos_timer = self.create_timer(
+                QOS_CHECK_TIMERR_PERIOD, self.check_qos_match
             )
 
         return qos_profile

--- a/ros_tcp_endpoint/subscriber.py
+++ b/ros_tcp_endpoint/subscriber.py
@@ -43,9 +43,7 @@ class RosSubscriber(RosReceiver):
         self.tcp_server = tcp_server
         self.queue_size = queue_size
 
-        qos_profile = QoSProfile(depth=queue_size)
-        qos_profile.history = QoSHistoryPolicy.KEEP_LAST
-        qos_profile.reliability = QoSReliabilityPolicy.RELIABLE
+        qos_profile = self.get_matched_qos(topic, queue_size)
 
         # Start Subscriber listener function
         self.subscription = self.create_subscription(
@@ -74,3 +72,27 @@ class RosSubscriber(RosReceiver):
         """
         self.destroy_subscription(self.subscription)
         self.destroy_node()
+
+    def get_matched_qos(self, topic, queue_size):
+        """Match QoS to existing publishers on the topic"""
+        qos_profile = QoSProfile(depth=queue_size)
+        try:
+            pub_info = self.get_publishers_info_by_topic(topic)
+            if pub_info:
+                source_qos = pub_info[0].qos_profile
+                qos_profile.reliability = source_qos.reliability
+                qos_profile.durability = source_qos.durability
+                self.get_logger().info(
+                    f"Matched QoS for {topic}: reliability={source_qos.reliability}, durability={source_qos.durability}"
+                )
+                return qos_profile
+            else:
+                self.get_logger().warn(
+                    f"No publisher found for topic {topic}, using default QoS"
+                )
+        except Exception as e:
+            self.get_logger().warn(
+                f"Failed to match QoS for topic {topic}: {e}, using default QoS"
+            )
+
+        return qos_profile

--- a/ros_tcp_endpoint/subscriber.py
+++ b/ros_tcp_endpoint/subscriber.py
@@ -114,7 +114,7 @@ class RosSubscriber(RosReceiver):
                 new_qos = (source_qos.reliability, source_qos.durability)
                 if self.current_qos != new_qos:
                     self.get_logger().warn(
-                        f"Publisher QoS changed for {self.topic}, recreating subscription"
+                        f"Publisher QoS did not match for {self.topic}, recreating subscription"
                     )
                     self.destroy_subscription(self.subscription)
                     qos_profile = self.get_matched_qos(self.topic, self.queue_size)

--- a/ros_tcp_endpoint/subscriber.py
+++ b/ros_tcp_endpoint/subscriber.py
@@ -47,7 +47,6 @@ class RosSubscriber(RosReceiver):
         self.subscription = self.create_subscription(
             self.msg, self.topic, self.send, qos_profile  # queue_size
         )
-        self.subscription
 
     def send(self, data):
         """

--- a/ros_tcp_endpoint/subscriber.py
+++ b/ros_tcp_endpoint/subscriber.py
@@ -12,11 +12,9 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-import rclpy
-import socket
+
 import re
 
-from rclpy.qos import QoSDurabilityPolicy, QoSHistoryPolicy, QoSReliabilityPolicy
 from rclpy.qos import QoSProfile
 
 from .communication import RosReceiver

--- a/ros_tcp_endpoint/subscriber.py
+++ b/ros_tcp_endpoint/subscriber.py
@@ -41,7 +41,7 @@ class RosSubscriber(RosReceiver):
         self.tcp_server = tcp_server
         self.queue_size = queue_size
 
-        qos_profile = self.get_matched_qos(topic, queue_size)
+        qos_profile = self.get_matched_qos(self.topic, self.queue_size)
 
         # Start Subscriber listener function
         self.subscription = self.create_subscription(
@@ -70,7 +70,7 @@ class RosSubscriber(RosReceiver):
         self.destroy_subscription(self.subscription)
         self.destroy_node()
 
-    def get_matched_qos(self, topic, queue_size):
+    def get_matched_qos(self, topic: str, queue_size: int) -> QoSProfile:
         """Match QoS to existing publishers on the topic"""
         qos_profile = QoSProfile(depth=queue_size)
         try:

--- a/ros_tcp_endpoint/subscriber.py
+++ b/ros_tcp_endpoint/subscriber.py
@@ -19,6 +19,8 @@ from rclpy.qos import QoSProfile
 
 from .communication import RosReceiver
 
+QOS_CHECK_TIMERR_PERIOD = 2.0
+
 
 class RosSubscriber(RosReceiver):
     """
@@ -40,8 +42,11 @@ class RosSubscriber(RosReceiver):
         self.msg = message_class
         self.tcp_server = tcp_server
         self.queue_size = queue_size
+        self.check_qos_timer = None
 
         qos_profile = self.get_matched_qos(self.topic, self.queue_size)
+
+        self.current_qos = (qos_profile.reliability, qos_profile.durability)
 
         # Start Subscriber listener function
         self.subscription = self.create_subscription(
@@ -67,6 +72,8 @@ class RosSubscriber(RosReceiver):
         Returns:
 
         """
+        if self.check_qos_timer:
+            self.destroy_timer(self.check_qos_timer)
         self.destroy_subscription(self.subscription)
         self.destroy_node()
 
@@ -87,9 +94,34 @@ class RosSubscriber(RosReceiver):
                 self.get_logger().warn(
                     f"No publisher found for topic {topic}, using default QoS"
                 )
+                if not self.check_qos_timer:
+                    self.check_qos_timer = self.create_timer(
+                        QOS_CHECK_TIMERR_PERIOD, self.check_qos_match
+                    )
         except Exception as e:
             self.get_logger().warn(
                 f"Failed to match QoS for topic {topic}: {e}, using default QoS"
             )
 
         return qos_profile
+
+    def check_qos_match(self):
+        try:
+            pub_info = self.get_publishers_info_by_topic(self.topic)
+            if pub_info:
+                source_qos = pub_info[0].qos_profile
+                new_qos = (source_qos.reliability, source_qos.durability)
+                if self.current_qos != new_qos:
+                    self.get_logger().warn(
+                        f"Publisher QoS changed for {self.topic}, recreating subscription"
+                    )
+                    self.destroy_subscription(self.subscription)
+                    qos_profile = self.get_matched_qos(self.topic, self.queue_size)
+                    self.subscription = self.create_subscription(
+                        self.msg, self.topic, self.send, qos_profile
+                    )
+                    self.current_qos = new_qos
+                self.destroy_timer(self.check_qos_timer)
+                self.check_qos_timer = None
+        except Exception as e:
+            self.get_logger().debug(f"QoS check failed for {self.topic}: {e}")


### PR DESCRIPTION
<!--
Nexxis PR Template
Use this template for all pull requests: features, bugfixes, refactors, tech debt, etc.
Please remove or skip any sections that are not relevant to your PR.
-->

# Overview
<!-- Describe the purpose of this PR. This should allow any one unfamiliar with
the work to understand the context. Aim for 2–3 sentences. Feel free to use existing
documentation or items to aid as support materials, via links, as long as the links
are long-lived. -->
The `ros-tcp-endpoint`'s subscription to topics always defaults to the default QoS Profile without considering the topic publisher's QoS settings. The changes introduced in this PR will allow `ros-tcp-endpoint`'s subscriber to match the topic publisher's QoS setting in terms of `Durability` and `Reliability`. `Depth` is passed down from the tcp client side so that is still respected. The rest of the QoS attributes rarely differ for ros2 in practice and therefore they are left untouched.


# Type(s) of Change
<!-- Uncomment the most relevant type(s) for this PR. -->
- 🚀 Feature
<!-- - 🐞 Bugfix -->
<!-- - ♻️ Refactor / Code Cleanup -->
<!-- - 📈 Tech Debt Reduction -->
<!-- - 📄 Documentation -->
<!-- - ⚙️ Infrastructure / Build System -->

# Description of Changes
<!-- Describe what was changed and why. Use bullet points if helpful. -->
- Added QoS matching for `ros-tcp-endpoint` subscribers

# Testing
<!-- Describe what testing you have done and how someone else can reproduce it. -->
- Tested in simulation using GOM's mock robot to ensure latched topic conveying all behaviors' list 
- Bench tested with a Panther Crawler to ensure existing operation is not broken

| Before | After |
|--------|-------|
| <img width="400" alt="before" src="https://github.com/user-attachments/assets/cc071529-4691-4b21-99cf-35f8c05fe45d" /> | <img width="400" alt="after" src="https://github.com/user-attachments/assets/5a2b39ab-3e18-4b3f-a6c9-004597067a18" /> |


# Documentation
## Testing Documentation
<!-- If **Yes**, please provide a link and summarize the changes. -->
**Does this change require new or updated testing documentation?** [No]  
<!-- [Testing Documentation Link]() -->

## LDR Documentation
<!-- Nexxis LDR repo (private): https://github.com/Nexxis-Technology/LDR -->

### LADR
<!-- If **Yes**, please provide a link to the decision document. -->
**Does this change require a LADR?** [No]  
<!-- [LADR Link]() -->

### LDDR
<!-- If **Yes**, please provide a link to the decision document. -->
**Does this change require a LDDR?** [No]  
<!-- [LDDR Link]() -->


# Additional Context (Optional)
<!-- Add any background, edge cases, or related PRs/issues that might help reviewers. -->


# PR Checklist

## Developer Submission Checklist
<!-- Please check off items you've completed before submitting. -->
- [x] Code builds and passes local/unit tests on your development system
- [x] Code conforms to repository linting and formatting standards
- [x] Relevant documentation is updated (e.g., Testing Docs, LADR)

## Reviewer Merge Checklist
<!-- Reviewers, please check off items you've completed before merging. -->
- [ ] Code has been reviewed and all comments have been addressed *
- [ ] Testing documentation has been reviewed (or confirmed not needed)
- [ ] LDR documentation (ADR & DDR) has been reviewed (or confirmed not needed)
- [ ] A review comment has been added outlining what was done, such as:
    - Code review performed
    - Code built locally
    - Code tested on a developer machine or test hardware

> \* GitHub branch protection rules should enforce this before merge.



